### PR TITLE
Copy Duffle binaries for embedding into generated code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,14 @@
                 "@types/node": "8.10.36"
             }
         },
+        "@types/mkdirp": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+            "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+            "requires": {
+                "@types/node": "8.10.36"
+            }
+        },
         "@types/mocha": {
             "version": "2.2.48",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -58,6 +66,14 @@
             "integrity": "sha512-uYPjTChD9TpjlvbBjNpZfNc64TBejBS52u7pbxhQLnlxw+5Em7wLb6DU2wdJVhJ2Mou7v50N0qgL4Gia5mmRYg==",
             "requires": {
                 "@types/request": "2.47.1"
+            }
+        },
+        "@types/tar": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.0.tgz",
+            "integrity": "sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==",
+            "requires": {
+                "@types/node": "8.10.36"
             }
         },
         "@types/tmp": {
@@ -344,6 +360,11 @@
                     }
                 }
             }
+        },
+        "chownr": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+            "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
         },
         "clone": {
             "version": "0.2.0",
@@ -744,6 +765,14 @@
                 "universalify": "0.1.2"
             }
         },
+        "fs-minipass": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+            "requires": {
+                "minipass": "2.3.5"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1089,6 +1118,17 @@
                     "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
                     "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
                     "dev": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
                 },
                 "vinyl": {
                     "version": "1.2.0",
@@ -1543,6 +1583,23 @@
             "version": "0.0.8",
             "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "minipass": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+            "requires": {
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+            }
+        },
+        "minizlib": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
+            "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
+            "requires": {
+                "minipass": "2.3.5"
+            }
         },
         "mkdirp": {
             "version": "0.5.1",
@@ -2102,14 +2159,17 @@
             "dev": true
         },
         "tar": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-            "dev": true,
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
+            "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "chownr": "1.1.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.3.5",
+                "minizlib": "1.1.1",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
             }
         },
         "through": {
@@ -2389,6 +2449,11 @@
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
             "dev": true
+        },
+        "yallist": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+            "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         },
         "yauzl": {
             "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -49,13 +49,17 @@
     "dependencies": {
         "@types/extract-zip": "^1.6.2",
         "@types/fs-extra": "^5.0.4",
+        "@types/mkdirp": "^0.5.2",
         "@types/request": "^2.47.1",
         "@types/request-promise-native": "^1.0.15",
+        "@types/tar": "^4.0.0",
         "@types/tmp": "0.0.33",
         "extract-zip": "^1.6.7",
         "fs-extra": "^7.0.0",
+        "mkdirp": "^0.5.1",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.5",
+        "tar": "^4.4.1",
         "tmp": "^0.0.33"
     },
     "devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 import { promptBundle, fileBundleSelection, repoBundleSelection, BundleSelection, parseNameOnly, bundleManifest } from './utils/bundleselection';
 import { RepoBundle, RepoBundleRef, BundleManifest } from './duffle/duffle.objectmodel';
-import { downloadZip } from './utils/download';
+import { downloadZip, downloadTar } from './utils/download';
 import { failed, Errorable } from './utils/errorable';
 import { fs } from './utils/fs';
 import { Cancellable, cancelled, accepted } from './utils/cancellable';
@@ -16,7 +16,7 @@ import { longRunning } from './utils/host';
 // was refusing to let me unzip to a temp location and move that directory to the desired
 // location.  So a bit more digging needed.
 // const DUFFLE_BAG_ZIP_LOCATION = "https://github.com/itowlson/duffle-bag/archive/pathfinding.zip";
-const DUFFLE_BAG_ZIP_LOCATION = "https://itowlsonmsbatest.blob.core.windows.net/dbag/duffle-bag-pathfinding.zip";
+const DUFFLE_BAG_ZIP_LOCATION = "https://itowlsonmsbatest.blob.core.windows.net/dbag/duffle-bag-edb.zip";
 
 export function activate(context: vscode.ExtensionContext) {
     const disposables = [
@@ -25,6 +25,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(...disposables);
 }
+
+type Platform = 'windows' | 'darwin' | 'linux';
+const PLATFORMS: Platform[] = ['windows', 'darwin', 'linux'];
 
 async function generate(target?: any): Promise<void> {
     if (!target) {
@@ -107,14 +110,22 @@ async function generateCore(bundlePick: BundleSelection): Promise<void> {
             downloadZip(DUFFLE_BAG_ZIP_LOCATION, folder)
         );
         if (failed(dl)) {
-            vscode.window.showErrorMessage(dl.error[0]);
+            vscode.window.showErrorMessage(`Downloading self-installer template failed: ${dl.error[0]}`);
             return;
         }
     }
 
-    const m = await setBundle(g.value.folder, bundleInfo.result);
-    if (failed(m)) {
-        vscode.window.showErrorMessage(m.error[0]);
+    const sb = await setBundle(g.value.folder, bundleInfo.result);
+    if (failed(sb)) {
+        vscode.window.showErrorMessage(sb.error[0]);
+        return;
+    }
+
+    const dlbin = await longRunning("Downloading Duffle binaries...", () =>
+        downloadDuffleBinaries(g.value.folder)
+    );
+    if (failed(dlbin)) {
+        vscode.window.showErrorMessage(`Downloading Duffle binaries failed: ${dlbin.error[0]}`);
         return;
     }
 
@@ -167,6 +178,25 @@ async function setBundle(folder: string, bundle: BundleManifest): Promise<Errora
     }
 
     return { succeeded: true, result: null };
+}
+
+async function downloadDuffleBinaries(targetFolder: string): Promise<Errorable<null>> {
+    const dufflebinPath = path.join(targetFolder, 'dufflebin');
+    const dltasks = PLATFORMS.map((p) => downloadDuffleBinary(dufflebinPath, p));
+    const dlresults = await Promise.all(dltasks);
+    const firstFail = dlresults.find((r) => failed(r));
+    if (firstFail) {
+        return firstFail;
+    }
+    return { succeeded: true, result: null };
+}
+
+async function downloadDuffleBinary(dufflebinPath: string, platform: Platform): Promise<Errorable<null>> {
+    // TODO: for testing purposes, this is the Draft download location.  It needs to be replaced
+    // with the Duffle download location.
+    // TODO: make sure this doesn't conflict with having the directories .gitkeep-ed in the template.
+    const source = `https://azuredraft.blob.core.windows.net/draft/draft-v0.15.0-${platform}-amd64.tar.gz`;
+    return await downloadTar(source, dufflebinPath);
 }
 
 enum FolderAction { New, Overwrite, Update }

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -2,6 +2,8 @@ import * as request from 'request-promise-native';
 import * as extract from 'extract-zip';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
+import mkdirp = require('mkdirp');
+import * as tar from 'tar';
 
 import { fs } from './fs';
 import { Errorable, failed } from './errorable';
@@ -30,5 +32,45 @@ export async function downloadZip(source: string, destinationFolder: string): Pr
         return { succeeded: true, result: null };
     } catch (e) {
         return { succeeded: false, error: [`${e}`] };
+    }
+}
+
+export async function downloadTar(sourceUrl: string, destinationFolder: string): Promise<Errorable<null>> {
+    try {
+        const tempFileObj = tmp.fileSync({ prefix: "duffle-coat-" });
+        const downloadResult = await download(sourceUrl, tempFileObj.name);
+
+        if (failed(downloadResult)) {
+            return { succeeded: false, error: [`Failed to download ${sourceUrl}: error was ${downloadResult.error[0]}`] };
+        }
+
+        const tarfile = tempFileObj.name;
+
+        // untar it
+        const untarResult = await untar(tarfile, destinationFolder);
+        if (failed(untarResult)) {
+            return { succeeded: false, error: [`Failed to unpack ${sourceUrl}: error was ${untarResult.error[0]}`] };
+        }
+
+        tempFileObj.removeCallback();
+
+        return { succeeded: true, result: null };
+    } catch (e) {
+        return { succeeded: false, error: [`${e}`] };
+    }
+}
+
+async function untar(sourceFile: string, destinationFolder: string): Promise<Errorable<null>> {
+    try {
+        if (!(await fs.exists(destinationFolder))) {
+            mkdirp.sync(destinationFolder);
+        }
+        await tar.x({
+            cwd: destinationFolder,
+            file: sourceFile
+        });
+        return { succeeded: true, result: null };
+    } catch (e) {
+        return { succeeded: false, error: [`tar extract failed: ${e}`] };
     }
 }


### PR DESCRIPTION
The Electron app tries to incorporate the Duffle binaries during build.  As we don't want to include these in the template zip file, we download them at code generation time.

For now, as Duffle does not have a stable binary download, we download Draft instead, which of course fails at runtime, but proves the concept at generation time.