### PR TITLE
Use the 'latest' template version in real builds

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,8 +15,7 @@ import { longRunning } from './utils/host';
 // to not include a top-level directory called duffle-bag-pathfinding.  And fs.rename
 // was refusing to let me unzip to a temp location and move that directory to the desired
 // location.  So a bit more digging needed.
-// const DUFFLE_BAG_ZIP_LOCATION = "https://github.com/itowlson/duffle-bag/archive/pathfinding.zip";
-const DUFFLE_BAG_ZIP_LOCATION = "https://itowlsonmsbatest.blob.core.windows.net/dbag/duffle-bag-edb.zip";
+const DUFFLE_BAG_ZIP_LOCATION = "https://itowlsonmsbatest.blob.core.windows.net/dbag/duffle-bag-latest.zip";
 
 export function activate(context: vscode.ExtensionContext) {
     const disposables = [


### PR DESCRIPTION
Previous versions of the extension were linking to specific versions of the duffle-bag template.  We should get better about keeping the template in blob storage current, and have (non-dev) drops of duffle-coat use that 'latest' copy.  For dev branches of duffle-coat, we can create named snapshot zips of duffle-bag and edit the URL to test them, but should promote the named snapshot to latest in sync with merging the duffle-coat branch,