### PR TITLE
Prepare for initial preview release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # duffle-coat
-VS Code extension for generating CNAB self-installers
+
+A Visual Studio Code extension for generating CNAB self-installers.
+
+This extension adds a `Generate Self-Installer` command to the following items:
+
+* `bundle.json` or `bundle.cnab` files
+* Bundles in the [Duffle extension's](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.duffle-vscode) Bundles explorer
+
+The command generates an Electron application, which you can then run using `npm run dev` or package for distribution using `npm run package`.  Your bundle is embedded in the application.  If you choose the **Full bundle** option during generation, then all Docker images are also embedded in the application, allowing it to run entirely offline.
+
+Note that once generated, the Electron app code is entirely decoupled from your source bundle.  If you make changes to the bundle, you'll need to regenerate the Electron app (you can choose just to update the bundle rather than overwriting the entire app).
+
+## Known issues
+
+The **Full bundle** generation options currently requires you to _push_ all depended-on Docker images to a network repository before running it.  (It is not sufficient for them to be present only in the local regsitry.)  This is a known issue with the `docker export` command.
+
+## Unknown issues
+
+I'm sure there are lots - please [report any you find](https://github.com/deislabs/duffle-coat/issues)!
+
+## Application template
+
+The application template lives in the `deislabs/duffle-bag` repo.  You are welcome to clone this and use it as the basis for an installer application without using this extension.  This extension just aims to make the job easier!

--- a/package.json
+++ b/package.json
@@ -3,12 +3,17 @@
     "displayName": "Duffle Coat",
     "description": "Generates CNAB self-installers",
     "version": "0.0.1",
+    "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.27.0"
     },
     "categories": [
         "Other"
+    ],
+    "keywords": [
+        "cnab",
+        "duffle"
     ],
     "activationEvents": [
         "onCommand:dufflecoat.generate"
@@ -80,5 +85,12 @@
         "tslint": "^5.8.0",
         "@types/node": "^8.10.25",
         "@types/mocha": "^2.2.42"
+    },
+    "extensionDependencies": [
+        "ms-kubernetes-tools.duffle-vscode"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/deislabs/duffle-coat"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,9 +15,6 @@ import * as shell from './utils/shell';
 import * as duffle from './duffle/duffle';
 import { move } from 'fs-extra';
 
-// TODO: Change to the GitHub release link once public
-// const DUFFLE_BAG_VERSION = 'master';
-// const DUFFLE_BAG_ZIP_LOCATION = "https://itowlsonmsbatest.blob.core.windows.net/dbag/duffle-bag-master-test-expand.zip";
 const DUFFLE_BAG_VERSION = '0.0.4';
 const DUFFLE_BAG_ZIP_LOCATION = `https://github.com/deislabs/duffle-bag/archive/${DUFFLE_BAG_VERSION}.zip`;
 


### PR DESCRIPTION
Some basic documentation and `package.json` cosmetics.

NOTE: We could merge this into the main Duffle extension if we want.  That might be easier for people who want to use this feature, but it feels like it adds 'noise' to the core UI that's additional to the core purpose of the Duffle extension.  We should make this decision before we publish it as a separate extension.