### PR TITLE
Fix for exporting thick bundles into dufflebags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.1
+
+- Fix for exporting thick bundles into self-installers
+
 ## 0.3.0
 - Update to Duffle binaries and template 0.3.0
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "duffle-coat",
     "displayName": "Duffle Coat",
     "description": "Generates CNAB self-installers",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {

--- a/src/duffle/duffle.ts
+++ b/src/duffle/duffle.ts
@@ -2,12 +2,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import * as config from '../config/config';
-import { Errorable, failed } from '../utils/errorable';
+import { Errorable } from '../utils/errorable';
 import * as shell from '../utils/shell';
 import { RepoBundle, LocalBundle } from './duffle.objectmodel';
-import { withTempDirectory } from '../utils/tempfile';
 import { fs } from '../utils/fs';
-import { localBundlePath } from './duffle.paths';
 // import { sharedTerminal } from './sharedterminal';
 // import * as pairs from '../utils/pairs';
 
@@ -85,11 +83,11 @@ export function bundles(sh: shell.Shell): Promise<Errorable<LocalBundle[]>> {
 }
 
 export async function upgrade(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'upgrade', `${bundleName} --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'upgrade', `${bundleName}`, {}, (s) => null);
 }
 
 export async function uninstall(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'uninstall', `${bundleName} --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'uninstall', `${bundleName}`, {}, (s) => null);
 }
 
 export async function pushBundle(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
@@ -97,42 +95,17 @@ export async function pushBundle(sh: shell.Shell, bundleName: string): Promise<E
 }
 
 export async function pull(sh: shell.Shell, bundleName: string): Promise<Errorable<null>> {
-    return await invokeObj(sh, 'pull', `${bundleName} --insecure`, {}, (s) => null);
+    return await invokeObj(sh, 'pull', `${bundleName}`, {}, (s) => null);
 }
 
-export async function exportFile(sh: shell.Shell, bundleFilePath: string, outputFile: string, thick: boolean): Promise<Errorable<null>> {
-    const directory = path.dirname(bundleFilePath);
-    const insecureFlag = bundleFilePath.endsWith('.json') ? '--insecure' : '';
+export async function exportFile(sh: shell.Shell, bundleFilePath: string, destination: string, thick: boolean): Promise<Errorable<null>> {
     const modeFlag = thick ? '' : '-t';
-    return await invokeObj(sh, 'export', `"${directory}" ${modeFlag} -o "${outputFile}" ${insecureFlag}`, {}, (_) => null);
+    return await invokeObj(sh, 'export', `"${bundleFilePath}" -f ${modeFlag} -o "${destination}"`, {}, (s) => null);
 }
 
 export async function exportBundle(sh: shell.Shell, bundleName: string, destination: string, thick: boolean): Promise<Errorable<null>> {
-    // Workaround until "duffle export bundleref..." lands:
-    // Because export currently takes a directory, we need to copy the bundle
-    // from local storage to a temp directory, and export that.
-    // Once duffle export takes a bundle reference, we can get rid of
-    // all this!
-    return await withTempDirectory<Errorable<null>>(async (tempdir) => {
-        async function gettempcopydest(sourcePath: string): Promise<string> {
-            const text = await fs.readFile(sourcePath, 'utf8');
-            if (text.startsWith('-')) {
-                return path.join(tempdir, 'bundle.cnab');
-            } else {
-                return path.join(tempdir, 'bundle.json');
-            }
-        }
-        const bundleParse = bundleName.split(':');
-        const bundleFile = await localBundlePath(bundleParse[0], bundleParse[1]);
-        if (failed(bundleFile)) {
-            return { succeeded: false, error: bundleFile.error };
-        }
-        const tempFile = await gettempcopydest(bundleFile.result);
-        await fs.copyFile(bundleFile.result, tempFile);
-        const insecureFlag = tempFile.endsWith('.json') ? '--insecure' : '';
-        const modeFlag = thick ? '' : '-t';
-        return await invokeObj(sh, 'export', `"${tempdir}" ${modeFlag} -o "${destination}" ${insecureFlag}`, {}, (s) => null);
-    });
+    const modeFlag = thick ? '' : '-t';
+    return await invokeObj(sh, 'export', `"${bundleName}" ${modeFlag} -o "${destination}"`, {}, (s) => null);
 }
 
 // export function showStatus(bundleName: string): void {


### PR DESCRIPTION
Because `duffle export` changed and they fixed an export woe.